### PR TITLE
Bugfix - rename forwarder, rename apiKey to clientKey

### DIFF
--- a/LeanplumAnalyticsEventForwarder.js
+++ b/LeanplumAnalyticsEventForwarder.js
@@ -16,7 +16,7 @@
 //  limitations under the License.
 
 (function (window) {
-    var name = 'LeanplumAnalyticsEventForwarder',
+    var name = 'Leanplum',
         MessageType = {
             SessionStart: 1,
             SessionEnd: 2,
@@ -226,10 +226,10 @@
 
         function setLeanPlumEnvironment() {
             if (window.mParticle.isSandbox) {
-                Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.apiKey);
+                Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }
             else {
-                Leanplum.setAppIdForProductionMode(forwarderSettings.appId, forwarderSettings.apiKey);
+                Leanplum.setAppIdForProductionMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }
         }
 


### PR DESCRIPTION
As visible [here](http://jssdkcdns.mparticle.com/js/v1/beab3f4d34281d45bfcdbbd7eb21c083/mparticle.js), the Leanplum configureForwarder settings sent form the server use the name 'Leanplum' rather than 'LeanplumAnalyticsEventForwarder'.  

Additionally, it is not `settings.apiKey` that is the proper key, but rather `clientKey`. Appboy uses apiKey, which is what I used as a baseline when coding up this integration.

ex: 
```
window.mParticle.configureForwarder({
   "name":"Leanplum",
   "moduleId":98,
   "isDebug":true,
   "isVisible":true,
   "isDebugString":"true",
   "hasDebugString":"false",
   "settings":  {"appId":"app_SXoOYT2li2hXX47ZokeOp0I1aSJZKHnnru11Dd3N7O0","clientKey":"prod_ANZ3ACHgDNhwM82y6MjAHIF3twGDhDNlDf7MSSbX1Io","userIdField":"customerId","androidDeviceId":"gaidThenAndroidId","iosDeviceId":"idfvForProdAndIdfaForDev"},"screenNameFilters":[],"screenAttributeFilters":[],"userIdentityFilters":"","userAttributeFilters":[],"eventNameFilters":[],"eventTypeFilters":[],"attributeFilters":[],"githubPath":null,"filteringEventAttributeValue":null});
```