### PR TITLE
Add new SDK features

### DIFF
--- a/src/LeanplumAnalyticsEventForwarder.js
+++ b/src/LeanplumAnalyticsEventForwarder.js
@@ -236,6 +236,10 @@
             var TWO_HOURS = 2*60*60;
             Leanplum.useSessionLength(forwarderSettings.sessionLength || TWO_HOURS);
 
+            if (forwarderSettings.enableRichInAppMessages) {
+                Leanplum.enableRichInAppMessages(true);
+            }
+
             if (window.mParticle.isSandbox) {
                 Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }

--- a/src/LeanplumAnalyticsEventForwarder.js
+++ b/src/LeanplumAnalyticsEventForwarder.js
@@ -233,6 +233,9 @@
         }
 
         function setLeanPlumEnvironment() {
+            var TWO_HOURS = 2*60*60;
+            Leanplum.useSessionLength(forwarderSettings.sessionLength || TWO_HOURS);
+
             if (window.mParticle.isSandbox) {
                 Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }

--- a/src/LeanplumAnalyticsEventForwarder.js
+++ b/src/LeanplumAnalyticsEventForwarder.js
@@ -236,7 +236,7 @@
             var TWO_HOURS = 2*60*60;
             Leanplum.useSessionLength(forwarderSettings.sessionLength || TWO_HOURS);
 
-            if (forwarderSettings.enableRichInAppMessages) {
+            if (forwarderSettings.enableRichInAppMessages === 'True') {
                 Leanplum.enableRichInAppMessages(true);
             }
 


### PR DESCRIPTION
This PR adds two new features, available in the previous versions of the Leanplum JS SDK:

## Prevent duplicate session handling

When end users navigate to a different page and `start()` is called, this creates a new session in Leanplum and obscures analytics. Calling the `useSessionLength()` method prevents this, by calling `startFromCache()` when there is an active session.

## Add the `enableRichInAppMessages` forwarder property

This allows customers to use this flag to enable Rich In-App message display, available in the JS SDK 1.8.0 and later.