### PR TITLE
Add link to mParticle Leanplum integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Leanplum Javascript Integration
 
-This repository contains the [Leanplum](www.leanplum.com) integration for the mParticle Javascript SDK.
+This repository contains the [Leanplum](https://docs.mparticle.com/integrations/leanplum/event/) integration for the mParticle Javascript SDK.
 
 #License
 


### PR DESCRIPTION
# Summary

The link to the Leanplum integration guide took users to the Leanplum site - this PR adds the correct URL.
