### PR TITLE
Set Leanplum environment correctly

### DIFF
--- a/LeanplumAnalyticsEventForwarder.js
+++ b/LeanplumAnalyticsEventForwarder.js
@@ -245,7 +245,7 @@ var mpLeanplumKit = (function (exports) {
           }
 
           function setLeanPlumEnvironment() {
-              if (window.mParticle.isSandbox) {
+              if (forwarderSettings.clientKey.startsWith('dev_')) {
                   Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
               }
               else {

--- a/dist/LeanplumAnalyticsEventForwarder.common.js
+++ b/dist/LeanplumAnalyticsEventForwarder.common.js
@@ -253,7 +253,7 @@ function isObject(val) {
                 Leanplum.enableRichInAppMessages(true);
             }
 
-            if (window.mParticle.isSandbox) {
+            if (forwarderSettings.clientKey.startsWith('dev_')) {
                 Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }
             else {

--- a/dist/LeanplumAnalyticsEventForwarder.iife.js
+++ b/dist/LeanplumAnalyticsEventForwarder.iife.js
@@ -252,7 +252,7 @@ var mpLeanplumKit = (function (exports) {
                   Leanplum.enableRichInAppMessages(true);
               }
 
-              if (window.mParticle.isSandbox) {
+              if (forwarderSettings.clientKey.startsWith('dev_')) {
                   Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
               }
               else {

--- a/src/LeanplumAnalyticsEventForwarder.js
+++ b/src/LeanplumAnalyticsEventForwarder.js
@@ -240,7 +240,7 @@
                 Leanplum.enableRichInAppMessages(true);
             }
 
-            if (window.mParticle.isSandbox) {
+            if (forwarderSettings.clientKey.startsWith('dev_')) {
                 Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             }
             else {


### PR DESCRIPTION
## Summary
- Changes the `setLeanPlumEnvironment` method to swap environments based on the clientKey, since mParticle.isSandbox doesn't seem to be 

## Testing Plan
- Run the app with a development Leanplum config. Without these changes, events are sent in production mode to leanplum. With these changes, they are sent in development mode.

## Reference Issue
