### PR TITLE
fix: Add missing sessionLength mock functions

### DIFF
--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -111,6 +111,7 @@ describe('Leanplum Forwarder', function() {
             this.logPurchaseName = null;
             this.apiKey = null;
             this.appId = null;
+            this.sessionLength = null;
             this.userId = null;
             this.userAttributes = {};
             this.userIdField = null;
@@ -181,6 +182,10 @@ describe('Leanplum Forwarder', function() {
                         self.userAttributes[key] = attributeDict[key];
                     }
                 }
+            };
+
+            this.useSessionLength = function (sessionLength) {
+                self.sessionLength = sessionLength;
             };
         };
 


### PR DESCRIPTION
## Summary
- Fix failing test by adding missing `sessionLength` mock functions

## Testing Plan
- Run automated tests

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME
