### PR TITLE
fix: Replace missing environment types api

### DIFF
--- a/src/LeanplumAnalyticsEventForwarder.js
+++ b/src/LeanplumAnalyticsEventForwarder.js
@@ -27,6 +27,10 @@
             CrashReport: 5,
             OptOut: 6,
             Commerce: 16
+        },
+        Environment = {
+            Production: 'production',
+            Development: 'development',
         };
 
     var constructor = function () {
@@ -240,7 +244,7 @@
                 Leanplum.enableRichInAppMessages(true);
             }
 
-            if (window.mParticle.getEnvironment() === window.mParticle.Types.Environment.Development) {
+            if (window.mParticle.getEnvironment() === Environment.Development) {
                 Leanplum.setAppIdForDevelopmentMode(forwarderSettings.appId, forwarderSettings.clientKey);
             } else {
                 Leanplum.setAppIdForProductionMode(forwarderSettings.appId, forwarderSettings.clientKey);


### PR DESCRIPTION
## Summary
- In a recent PR (#45) we introduced a reference to a new core SDK method, `window.mParticle.getEnvironment()`. We also referenced `window.mParticle.Types.Environment.Development` which is not actually publicly available. Replacing this reference with a local enum.

## Testing Plan
- Manually test the leanplum kit in a sample app

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME
